### PR TITLE
Build a docker image for CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,10 @@
 **
 
 # Except
+!/docker/**
 !requirements.txt
 !requirements-dev.txt
 !package.json
 !package-lock.json
-
+!/Makefile
+!/.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Ignore everything
+**
+
+# Except
+!requirements.txt
+!requirements-dev.txt
+!package.json
+!package-lock.json
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !/docker/**
 !requirements.txt
 !requirements-dev.txt
+!scripts/requirements.txt
 !package.json
 !package-lock.json
 !/Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:experimental
+FROM python-nodejs
+
+# Install prereqs
+RUN apt-get update
+RUN apt-get -y install sudo
+RUN apt-get -y install curl
+RUN apt-get -y install software-properties-common
+RUN apt-get -y install git
+
+# Install Python dev dependencies
+COPY requirements.txt ./
+COPY requirements-dev.txt ./
+RUN pip3 --default-timeout=1000 install -r requirements.txt
+RUN pip3 --default-timeout=1000 install -r requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON_FILES = main.py scripts/
 CSS_FILES = $(shell find static/css -name "*.css")
-.PHONY: format format-web run freeze format-check
+.PHONY: format format-web run freeze format-check docker-build docker-publish
 
 all: format-check
 
@@ -25,3 +25,10 @@ format-check:
 	(isort -rc $(PYTHON_FILES) --check-only --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88) && (black -t py37 --check $(PYTHON_FILES)) || (echo "run \"make format\" to format the code"; exit 1)
 	pylint -j0 $(PYTHON_FILES)
 	mypy --show-error-codes $(PYTHON_FILES)
+
+
+docker-build: docker/Dockerfile docker/Makefile
+	cd docker && make build
+
+docker-publish: docker/Dockerfile docker/Makefile
+	cd docker && make publish

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:experimental
 FROM python-nodejs
 
 # Install prereqs
@@ -9,7 +8,7 @@ RUN apt-get -y install software-properties-common
 RUN apt-get -y install git
 
 # Install Python dev dependencies
-COPY requirements.txt ./
-COPY requirements-dev.txt ./
+COPY ../requirements.txt ./
+COPY ../requirements-dev.txt ./
 RUN pip3 --default-timeout=1000 install -r requirements.txt
 RUN pip3 --default-timeout=1000 install -r requirements-dev.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,5 +10,7 @@ RUN apt-get -y install git
 # Install Python dev dependencies
 COPY ./requirements.txt ./
 COPY ./requirements-dev.txt ./
+RUN mkdir ./scripts/
+COPY ./scripts/requirements-dev.txt ./scripts/
 RUN pip3 --default-timeout=1000 install -r requirements.txt
 RUN pip3 --default-timeout=1000 install -r requirements-dev.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -y install software-properties-common
 RUN apt-get -y install git
 
 # Install Python dev dependencies
-COPY ../requirements.txt ./
-COPY ../requirements-dev.txt ./
+COPY ./requirements.txt ./
+COPY ./requirements-dev.txt ./
 RUN pip3 --default-timeout=1000 install -r requirements.txt
 RUN pip3 --default-timeout=1000 install -r requirements-dev.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,6 @@ RUN apt-get -y install git
 COPY ./requirements.txt ./
 COPY ./requirements-dev.txt ./
 RUN mkdir ./scripts/
-COPY ./scripts/requirements-dev.txt ./scripts/
+COPY ./scripts/requirements.txt ./scripts/
 RUN pip3 --default-timeout=1000 install -r requirements.txt
 RUN pip3 --default-timeout=1000 install -r requirements-dev.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python-nodejs
+FROM nikolaik/python-nodejs:python3.7-nodejs12
 
 # Install prereqs
 RUN apt-get update

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/bash
-APP_NAME = mini-conf/default
+APP_NAME = mini-conf
 VERSION = 1.0
 COMMIT_SHA1 = $(shell git rev-parse HEAD)
 DOCKER_REPO = acl2020

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash
 APP_NAME = mini-conf/default
-VERSION = 1.6.0
+VERSION = 1.0
 COMMIT_SHA1 = $(shell git rev-parse HEAD)
 DOCKER_REPO = acl2020
 # relative path to the root directories

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -13,7 +13,7 @@ DEPENDENT_FILES += $(ROOT_DIR)/requirements.txt
 DEPENDENT_FILES += $(ROOT_DIR)/scripts/requirements.txt
 DEPENDENT_FILES += $(ROOT_DIR)/Makefile
 
-.PHONY: git-status git-archive build tag publish
+.PHONY: git-status build publish login
 
 # check if relevant changes are committed
 git-status: $(DEPENDENT_FILES)
@@ -35,7 +35,11 @@ build: git-status
 		.
 
 # publish the docker image
-publish: build
+publish: build login
 	@echo 'publish $(VERSION) $(COMMIT_SHA1) to $(DOCKER_REPO)'
 	docker push $(DOCKER_REPO)/$(APP_NAME):$(VERSION)
 	docker push $(DOCKER_REPO)/$(APP_NAME):$(COMMIT_SHA1)
+
+# login to Docker Hub
+login:
+	docker login

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/bash
-APP_NAME = mini-conf
+APP_NAME = miniconf
 VERSION = 1.0
 COMMIT_SHA1 = $(shell git rev-parse HEAD)
 DOCKER_REPO = acl2020

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -22,10 +22,10 @@ git-status: $(DEPENDENT_FILES)
 # build the docker image
 build: git-status
 	cd ..; docker build \
+		-t $(APP_NAME):$(VERSION) \
 		-t $(APP_NAME):$(COMMIT_SHA1) \
-		-t $(APP_NAME):$(BRANCH_NAME) \
+		-t $(DOCKER_REPO)/$(APP_NAME):$(VERSION) \
 		-t $(DOCKER_REPO)/$(APP_NAME):$(COMMIT_SHA1) \
-		-t $(DOCKER_REPO)/$(APP_NAME):$(BRANCH_NAME) \
 		--label branch=$(BRANCH_NAME) \
 		--label commit=$(COMMIT_SHA1) \
 		-f docker/Dockerfile \
@@ -36,6 +36,6 @@ build: git-status
 
 # publish the docker image
 publish: build
-	@echo 'publish $(BRANCH_NAME) $(COMMIT_SHA1) to $(DOCKER_REPO)'
+	@echo 'publish $(VERSION) $(COMMIT_SHA1) to $(DOCKER_REPO)'
+	docker push $(DOCKER_REPO)/$(APP_NAME):$(VERSION)
 	docker push $(DOCKER_REPO)/$(APP_NAME):$(COMMIT_SHA1)
-	docker push $(DOCKER_REPO)/$(APP_NAME):$(BRANCH_NAME)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,41 @@
+SHELL = /bin/bash
+APP_NAME = mini-conf/default
+VERSION = 1.6.0
+COMMIT_SHA1 = $(shell git rev-parse HEAD)
+DOCKER_REPO = acl2020
+# relative path to the root directories
+ROOT_DIR = $(shell cd .. && pwd -P)
+# relevant files for tracking the docker image version
+DEPENDENT_FILES = $(ROOT_DIR)/.dockerignore
+DEPENDENT_FILES += $(ROOT_DIR)/docker
+DEPENDENT_FILES += $(ROOT_DIR)/requirements-dev.txt
+DEPENDENT_FILES += $(ROOT_DIR)/requirements.txt
+DEPENDENT_FILES += $(ROOT_DIR)/scripts/requirements.txt
+DEPENDENT_FILES += $(ROOT_DIR)/Makefile
+
+.PHONY: git-status git-archive build tag publish
+
+# check if relevant changes are committed
+git-status: $(DEPENDENT_FILES)
+	@ [[ -z $$(git status $(DEPENDENT_FILES) --porcelain -uno) ]] || (echo "please commit your changes in $(DEPENDENT_FILES)"; exit 1)
+
+# build the docker image
+build: git-status
+	cd ..; docker build \
+		-t $(APP_NAME):$(COMMIT_SHA1) \
+		-t $(APP_NAME):$(BRANCH_NAME) \
+		-t $(DOCKER_REPO)/$(APP_NAME):$(COMMIT_SHA1) \
+		-t $(DOCKER_REPO)/$(APP_NAME):$(BRANCH_NAME) \
+		--label branch=$(BRANCH_NAME) \
+		--label commit=$(COMMIT_SHA1) \
+		-f docker/Dockerfile \
+		--ssh default \
+		-m 4g \
+		-c 2 \
+		.
+
+# publish the docker image
+publish: build
+	@echo 'publish $(BRANCH_NAME) $(COMMIT_SHA1) to $(DOCKER_REPO)'
+	docker push $(DOCKER_REPO)/$(APP_NAME):$(COMMIT_SHA1)
+	docker push $(DOCKER_REPO)/$(APP_NAME):$(BRANCH_NAME)


### PR DESCRIPTION
Installing all Python packages during CI is slow. Probably good to use a pre-built docker image.

I pushed on [here](https://hub.docker.com/r/acl2020/miniconf).