### PR TITLE
temporarily remove /calendar.html due to sitedata mismatch

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,14 +98,13 @@ def paper_vis():
 @app.route("/calendar.html")
 def schedule():
     data = _data()
-    # FIXME: Need to update the sitedata_acl2020/highlighted.csv
-    data["day"] = {}
-    # data["day"] = {
-    #     "speakers": site_data["speakers"],
-    #     "highlighted": [
-    #         format_paper(by_uid["papers"][h["UID"]]) for h in site_data["highlighted"]
-    #     ],
-    # }
+    data["day"] = {
+        "speakers": site_data["speakers"],
+        # There is no "Highlighted Papers" for ACL2020.
+        # "highlighted": [
+        #     format_paper(by_uid["papers"][h["UID"]]) for h in site_data["highlighted"]
+        # ],
+    }
     return render_template("schedule.html", **data)
 
 

--- a/main.py
+++ b/main.py
@@ -98,12 +98,14 @@ def paper_vis():
 @app.route("/calendar.html")
 def schedule():
     data = _data()
-    data["day"] = {
-        "speakers": site_data["speakers"],
-        "highlighted": [
-            format_paper(by_uid["papers"][h["UID"]]) for h in site_data["highlighted"]
-        ],
-    }
+    # FIXME: Need to update the sitedata_acl2020/highlighted.csv
+    data["day"] = {}
+    # data["day"] = {
+    #     "speakers": site_data["speakers"],
+    #     "highlighted": [
+    #         format_paper(by_uid["papers"][h["UID"]]) for h in site_data["highlighted"]
+    #     ],
+    # }
     return render_template("schedule.html", **data)
 
 


### PR DESCRIPTION
With #68, we use ACL accepted papers, but the `highlighted.csv` is not synced, so `make freeze` failed. See https://github.com/acl-org/acl-2020-virtual-conference/runs/768543817

Actually, we don't have the notion of "Highlighted Papers" in ACL2020, so this PR simply comment out this part.

We should probably delete `highlighted.csv` in sitedata_acl2020.