### PR TITLE
Add QA session timings

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ def main(site_data_path):
             by_uid[typ][p["UID"]] = p
 
     display_time_format = "%H:%M"
-    for session_name, session_info in site_data["poster_schedule"].items():
+    for session_info in site_data["poster_schedule"].values():
         for paper in session_info["posters"]:
             if "sessions" not in by_uid["papers"][paper["id"]]:
                 by_uid["papers"][paper["id"]]["sessions"] = []

--- a/main.py
+++ b/main.py
@@ -45,12 +45,13 @@ def main(site_data_path):
             by_uid[typ][p["UID"]] = p
 
     display_time_format = "%H:%M"
-    for session_info in site_data["poster_schedule"].values():
+    for session_name, session_info in site_data["poster_schedule"].items():
         for paper in session_info["posters"]:
             if "sessions" not in by_uid["papers"][paper["id"]]:
                 by_uid["papers"][paper["id"]]["sessions"] = []
             time = datetime.strptime(session_info["date"], "%Y-%m-%d_%H:%M:%S")
             start_time = time.strftime(display_time_format)
+            start_day = time.strftime("%a")
             end_time = time + timedelta(hours=qa_session_length_hr)
             end_time = end_time.strftime(display_time_format)
             time_string = "({}-{} GMT)".format(start_time, end_time)
@@ -60,6 +61,7 @@ def main(site_data_path):
                 {
                     "time": time,
                     "time_string": time_string,
+                    "session": " ".join([start_day, "Session", session_name]),
                     "zoom_link": paper["join_link"],
                     "ical_link": calendar_stub
                     + "/poster_{}.{}.ics".format(paper["id"], current_num_sessions),

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,7 @@ python_version = 3.7
 incremental = False
 strict_optional = False
 
-[mypy-sklearn.*,transformers.*,flask_frozen.*,flaskext.*,ics.*]
+[mypy-sklearn.*,transformers.*,flask_frozen.*,flaskext.*,ics.*,icalendar.*]
 ignore_missing_imports = True
 
 [mypy-rocketchat_API.*]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ frozen-flask
 Flask-Markdown
 tqdm
 PyYAML
+icalendar
+pytz

--- a/static/js/time-extend.js
+++ b/static/js/time-extend.js
@@ -1,0 +1,21 @@
+add_local_tz = (selector) => {
+  const regex_time = new RegExp("\\((.*)-(.*) (.*)\\)");
+  const guess_tz = moment.tz.guess(true);
+
+  $(selector).each(function () {
+    const t = $(this).text();
+    const res = regex_time.exec(t);
+    if (res) {
+      const start_time = moment.utc(`2020-04-30 ${res[1]}`);
+      const end_time = moment.utc(`2020-04-30 ${res[2]}`);
+      // console.log(start_time,end_time,"--- start_time,end_time");
+      // console.log(start_time.tz(guess_tz).format('h:mm A'),"--- start_time.");
+      // console.log(end_time.tz(guess_tz).format('h:mm A z'),"--- start_time.");
+      const local_start = start_time.tz(guess_tz).format("HH:mm");
+      const local_end_and_tz = end_time.tz(guess_tz).format("HH:mm z");
+      $(this).text(
+        `(${res[1]}-${res[2]} ${res[3]} / ${local_start}-${local_end_and_tz})`
+      );
+    }
+  });
+};

--- a/static/js/time-extend.js
+++ b/static/js/time-extend.js
@@ -8,13 +8,18 @@ add_local_tz = (selector) => {
     if (res) {
       const start_time = moment.utc(`2020-04-30 ${res[1]}`);
       const end_time = moment.utc(`2020-04-30 ${res[2]}`);
-      // console.log(start_time,end_time,"--- start_time,end_time");
-      // console.log(start_time.tz(guess_tz).format('h:mm A'),"--- start_time.");
-      // console.log(end_time.tz(guess_tz).format('h:mm A z'),"--- start_time.");
       const local_start = start_time.tz(guess_tz).format("HH:mm");
-      const local_end_and_tz = end_time.tz(guess_tz).format("HH:mm z");
+      const local_end = end_time.tz(guess_tz);
+      const local_end_and_tz = local_end.format("HH:mm z");
+      const dd = local_end.dayOfYear() - end_time.utc().dayOfYear();
+      let dd_str = "";
+      if (dd > 0) {
+        dd_str = ` +${dd}d`;
+      } else if (dd < 0) {
+        dd_str = ` ${dd}d`;
+      }
       $(this).text(
-        `(${res[1]}-${res[2]} ${res[3]} / ${local_start}-${local_end_and_tz})`
+        `(${res[1]}-${res[2]} ${res[3]} / ${local_start}-${local_end_and_tz}${dd_str})`
       );
     }
   });

--- a/templates/poster.html
+++ b/templates/poster.html
@@ -43,6 +43,10 @@
       >{{ "," if not loop.last }}
       {% endfor %}
     </p>
+    <p class="card-text text-center">
+      <span class="">Track:</span>
+      {{ paper.content.track }}
+    </p>
     <div class="text-center p-3">
       <a class="card-link" data-toggle="collapse" role="button" href="#details">
         Abstract
@@ -65,7 +69,7 @@
     <div class=" text-center text-muted text-monospace ">
     {% for session in paper.content.sessions %}
       <div>
-      {{paper.content.track}}
+      {{session.session}}
       <span class="session_times">{{session.time_string}}</span>
       [<a href="{{session.zoom_link}}" target="_blank"  class="card-link">Live QA</a>]
       [<a target="_blank" href="{{session.ical_link}}">Cal</a>]

--- a/templates/poster.html
+++ b/templates/poster.html
@@ -139,7 +139,12 @@
     })
 </script>
 
-
+<script src="static/js/time-extend.js"></script>
+<script>
+  $(document).ready(()=>{
+    add_local_tz('.session_times');
+  })
+</script>
 
 
 

--- a/templates/poster.html
+++ b/templates/poster.html
@@ -66,7 +66,7 @@
     {% for session in paper.content.sessions %}
       <div>
       {{paper.content.track}}
-      <span class="session_times">{{session.time}}</span>
+      <span class="session_times">{{session.time_string}}</span>
       [<a href="{{session.zoom_link}}" target="_blank"  class="card-link">Live QA</a>]
       [<a target="_blank" href="{{session.ical_link}}">Cal</a>]
       </div>


### PR DESCRIPTION
* Display the two session times on each poster page (in UTC + local timezone, as with ICLR)
* Add iCal download links for each session

Solves https://github.com/acl-org/acl-2020-virtual-conference/issues/74

Tests will fail until https://github.com/acl-org/acl-2020-virtual-conference-sitedata/pull/7 is merged