### PR TITLE
Add css to allow linebreaks in FAQ answers

### DIFF
--- a/templates/components.html
+++ b/templates/components.html
@@ -126,7 +126,7 @@
         data-parent="#accordionExample"
       >
         <div class="card-body">
-          <div style="white-space: pre-wrap">{{qa.Answer}}</div>
+          <div style="white-space: pre-wrap">{{qa.Answer|markdown}}</div>
         </div>
       </div>
     </div>

--- a/templates/components.html
+++ b/templates/components.html
@@ -126,7 +126,7 @@
         data-parent="#accordionExample"
       >
         <div class="card-body">
-          {{qa.Answer}}
+          <div style="white-space: pre-wrap">{{qa.Answer}}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Just a short inline css property to allow linebreaks in FAQ answers (https://github.com/acl-org/acl-2020-virtual-conference/issues/20).