### PR TITLE
Make different tabs for different days and split speakers by days

### DIFF
--- a/main.py
+++ b/main.py
@@ -154,13 +154,19 @@ def paper_vis():
 @app.route("/calendar.html")
 def schedule():
     data = _data()
-    data["day"] = {
-        "speakers": site_data["speakers"],
-        # There is no "Highlighted Papers" for ACL2020.
-        # "highlighted": [
-        #     format_paper(by_uid["papers"][h["UID"]]) for h in site_data["highlighted"]
-        # ],
-    }
+    days = ["Monday", "Tuesday", "Wednesday"]
+    for day in days:
+        data[day] = {
+            "speakers": [
+                s for s in site_data["speakers"]
+                if s["day"] == day
+            ],
+            # There is no "Highlighted Papers" for ACL2020.
+            # "highlighted": [
+            #     format_paper(by_uid["papers"][h["UID"]])
+            #     for h in site_data["highlighted"]
+            # ],
+        }
     return render_template("schedule.html", **data)
 
 

--- a/main.py
+++ b/main.py
@@ -157,10 +157,7 @@ def schedule():
     days = ["Monday", "Tuesday", "Wednesday"]
     for day in days:
         data[day] = {
-            "speakers": [
-                s for s in site_data["speakers"]
-                if s["day"] == day
-            ],
+            "speakers": [s for s in site_data["speakers"] if s["day"] == day],
             # There is no "Highlighted Papers" for ACL2020.
             # "highlighted": [
             #     format_paper(by_uid["papers"][h["UID"]])

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -8,7 +8,9 @@
 
 {% block tabs %}
 {{ components.tabs([("calendar", "Calendar", "active"),
-        ("day", "Keynotes", "")]) }}
+                    ("mon", "Monday", ""),
+                    ("tue", "Tuesday", ""),
+                    ("wed", "Wednesday", "")]) }}
 {% endblock %}
 
 {% block content %}
@@ -41,15 +43,54 @@
 
   <div
     class="tab-pane fade"
-    id="tab-day"
+    id="tab-mon"
     role="tabpanel"
     aria-labelledby="nav-profile-tab"
   >
-    <div id="day">
+    <div id="mon">
       <!-- Speakers -->
       {{ components.section("Speakers") }}
       <div class="speakers">
-        {{ components.speakergroup(day.speakers) }}
+        {{ components.speakergroup(Monday.speakers) }}
+      </div>
+    </div>
+
+    <script type="text/javascript">
+      lazyLoader();
+    </script>
+  </div>
+
+
+  <div
+    class="tab-pane fade"
+    id="tab-tue"
+    role="tabpanel"
+    aria-labelledby="nav-profile-tab"
+  >
+    <div id="tue">
+      <!-- Speakers -->
+      {{ components.section("Speakers") }}
+      <div class="speakers">
+        {{ components.speakergroup(Tuesday.speakers) }}
+      </div>
+    </div>
+
+    <script type="text/javascript">
+      lazyLoader();
+    </script>
+  </div>
+
+  <div
+    class="tab-pane fade"
+    id="tab-wed"
+    role="tabpanel"
+    aria-labelledby="nav-profile-tab"
+  >
+    <div id="wed">
+      <!-- Speakers -->
+      {{ components.section("Speakers") }}
+      <div class="speakers">
+        {{ components.speakergroup(Wednesday.speakers) }}
       </div>
     </div>
 
@@ -58,4 +99,6 @@
     </script>
   </div>
 </div>
+
+
 {% endblock %}


### PR DESCRIPTION
Follow ICLR and split speakers in days 
Needs https://github.com/acl-org/acl-2020-virtual-conference-sitedata/pull/19 to get merged
Related issue: #23
 