### PR TITLE
Tutorial show schedule

### DIFF
--- a/static/js/tutorial_calendar.js
+++ b/static/js/tutorial_calendar.js
@@ -1,211 +1,196 @@
 function make_cal(name) {
+  // console.log(location.search, "--- location.search");
 
-    // console.log(location.search, "--- location.search");
+  const current_tz = getUrlParameter("tz") || moment.tz.guess();
+  const tzNames = [...moment.tz.names()];
 
-    const current_tz = getUrlParameter('tz') || moment.tz.guess();
-    const tzNames = [...moment.tz.names()];
+  const setupTZSelector = () => {
+    const tzOptons = d3.select("#tzOptions");
+    tzOptons
+      .selectAll("option")
+      .data(tzNames)
+      .join("option")
+      .attr("data-tokens", (d) => d.split("/").join(" "))
+      .text((d) => d);
+    $(".selectpicker")
+      .selectpicker("val", current_tz)
+      .on("changed.bs.select", function (
+        e,
+        clickedIndex,
+        isSelected,
+        previousValue
+      ) {
+        new_tz = tzNames[clickedIndex];
+        window.open(`${window.location.pathname}?tz=${new_tz}`, "_self");
+      });
+  };
 
-    const setupTZSelector = () => {
-        const tzOptons = d3.select('#tzOptions')
-        tzOptons.selectAll('option').data(tzNames)
-          .join('option')
-          .attr('data-tokens', d => d.split("/").join(" "))
-          .text(d => d)
-        $('.selectpicker')
-          .selectpicker('val', current_tz)
-          .on('changed.bs.select',
-            function (e, clickedIndex, isSelected, previousValue) {
-                new_tz = tzNames[clickedIndex]
-                window.open(window.location.pathname+'?tz='+new_tz, '_self');
-            })
+  setupTZSelector();
+
+  // requires moments.js
+  const enumerateDaysBetweenDates = function (startDate, endDate) {
+    const dates = [];
+
+    // console.log(startDate, endDate, "--- startDate, endDate");
+
+    const currDate = moment(startDate);
+    const lastDate = moment(endDate);
+
+    dates.push(currDate.clone());
+    while (currDate.add(1, "days").diff(lastDate) < 0) {
+      // console.log(currDate, "--- currDate");
+      dates.push(currDate.clone());
     }
 
-    setupTZSelector();
+    dates.push(lastDate);
+    return dates;
+  };
 
-    // requires moments.js
-    const enumerateDaysBetweenDates = function (startDate, endDate) {
-        const dates = [];
+  $.get("serve_config.json").then((config) => {
+    $.get(name).then((events) => {
+      const all_cals = [];
+      const timezoneName = current_tz;
 
-        // console.log(startDate, endDate, "--- startDate, endDate");
+      const min_date = d3.min(events.map((e) => e.start));
+      let min_hours =
+        d3.min(events.map((e) => moment(e.start).tz(timezoneName).hours())) - 1;
+      let max_hours =
+        d3.max(events.map((e) => moment(e.end).tz(timezoneName).hours())) + 1;
+      if (min_hours < 0 || max_hours > 24) {
+        min_hours = 0;
+        max_hours = 24;
+      }
+      // console.log(min_hours, max_hours);
+      const { Calendar } = tui;
+      const calendar = new Calendar("#calendar", {
+        defaultView: "day",
+        isReadOnly: true,
+        // useDetailPopup: true,
+        taskView: false,
+        scheduleView: ["time"],
+        usageStatistics: false,
+        // week: {
+        //     workweek: !config.calendar["saturday"],
+        //     hourStart: min_hours,
+        //     hourEnd: max_hours
+        // },
+        timezones: [
+          {
+            timezoneOffset: -moment.tz
+              .zone(timezoneName)
+              .utcOffset(moment(min_date)),
+            displayLabel: timezoneName,
+            tooltip: timezoneName,
+          },
+        ],
+        // timezones: [{
+        //     getTimezoneOffset: 540,
+        //     displayLabel: 'a',
+        //     tooltip: timezoneName
+        // }],
+        template: {
+          // monthDayname: function (dayname) {
+          //     return '<span class="calendar-week-dayname-name">' + dayname.label + '</span>';
+          // },
+          time(schedule) {
+            return `<strong>${moment(schedule.start.getTime())
+              .tz(timezoneName)
+              .format("hh:mm")}-${moment(schedule.end.getTime())
+              .tz(timezoneName)
+              .format("hh:mm")}</strong> ${schedule.title}`;
+          },
+          milestone(schedule) {
+            return `<span class="calendar-font-icon ic-milestone-b"></span> <span style="background-color: ${schedule.bgColor}"> M: ${schedule.title}</span>`;
+          },
+          // weekDayname: function (model) {
+          //     const parts = model.renderDate.split('-');
+          //     return '<span class="tui-full-calendar-dayname-name"> ' + parts[1] + '/' + parts[2] + '</span>&nbsp;&nbsp;<span class="tui-full-calendar-dayname-name">' + model.dayName + '</span>';
+          // },
+        },
+      });
+      calendar.setDate(Date.parse(min_date));
+      calendar.createSchedules(events);
+      calendar.on({
+        clickSchedule(e) {
+          const s = e.schedule;
+          if (s.location.length > 0) {
+            window.open(s.location, "_blanket");
+          }
+        },
+      });
 
-        const currDate = moment(startDate);
-        const lastDate = moment(endDate);
+      all_cals.push(calendar);
 
-        dates.push(currDate.clone());
-        while (currDate.add(1, 'days').diff(lastDate) < 0) {
-            // console.log(currDate, "--- currDate");
-            dates.push(currDate.clone());
-        }
+      const cols = config.calendar.colors;
+      if (cols) {
+        const cals = [];
+        Object.keys(cols).forEach((k) => {
+          const v = cols[k];
+          cals.push({
+            id: k,
+            name: k,
+            bgColor: v,
+          });
+        });
 
-        dates.push(lastDate);
-        return dates;
-    };
+        calendar.setCalendars(cals);
+      }
 
+      const week_dates = enumerateDaysBetweenDates(
+        calendar.getDateRangeStart().toDate(),
+        calendar.getDateRangeEnd().toDate()
+      );
 
-    $.get('serve_config.json').then(config => {
-        $.get(name).then(events => {
+      const c_sm = d3.select("#calendar_small");
+      const i = 0;
+      c_sm.append("div").attr("id", `cal__${i}`);
+      const cal = new Calendar(`#cal__${i}`, {
+        defaultView: "day",
+        isReadOnly: true,
+        // useDetailPopup: true,
+        taskView: false,
+        scheduleView: ["time"],
+        usageStatistics: false,
 
-            const all_cals = [];
-            const timezoneName = current_tz;
+        timezones: [
+          {
+            timezoneOffset: -moment.tz
+              .zone(timezoneName)
+              .utcOffset(moment(min_date)),
+            displayLabel: timezoneName,
+            tooltip: timezoneName,
+          },
+        ],
+      });
 
-            const min_date = d3.min(events.map(e => e.start));
-            var min_hours = d3.min(events.map(e => moment(e.start).tz(timezoneName).hours())) -1;
-            var max_hours = d3.max(events.map(e => moment(e.end).tz(timezoneName).hours())) +1;
-            if(min_hours < 0 || max_hours > 24) {
-                min_hours = 0;
-                max_hours = 24;
-            }
-            // console.log(min_hours, max_hours);
-            const Calendar = tui.Calendar;
-            const calendar = new Calendar('#calendar', {
-                defaultView: 'day',
-                isReadOnly: true,
-                // useDetailPopup: true,
-                taskView: false,
-                scheduleView: ['time'],
-                usageStatistics: false,
-                // week: {
-                //     workweek: !config.calendar["saturday"],
-                //     hourStart: min_hours,
-                //     hourEnd: max_hours
-                // },
-                timezones: [{
-                    timezoneOffset: -moment.tz.zone(timezoneName)
-                      .utcOffset(moment(min_date)),
-                    displayLabel: timezoneName,
-                    tooltip: timezoneName
-                }],
-                // timezones: [{
-                //     getTimezoneOffset: 540,
-                //     displayLabel: 'a',
-                //     tooltip: timezoneName
-                // }],
-                template: {
-                    // monthDayname: function (dayname) {
-                    //     return '<span class="calendar-week-dayname-name">' + dayname.label + '</span>';
-                    // },
-                    time: function (schedule) {
-                        return '<strong>' + moment(schedule.start.getTime())
-                          .tz(timezoneName)
-                          .format('hh:mm') + 
-                          '-' +
-                          moment(schedule.end.getTime())
-                          .tz(timezoneName)
-                          .format('hh:mm') + 
-                          '</strong> ' + schedule.title;
-                    },
-                    milestone: function (schedule) {
-                        return '<span class="calendar-font-icon ic-milestone-b"></span> <span style="background-color: ' + schedule.bgColor + '"> M: ' + schedule.title + '</span>';
-                    },
-                    // weekDayname: function (model) {
-                    //     const parts = model.renderDate.split('-');
-                    //     return '<span class="tui-full-calendar-dayname-name"> ' + parts[1] + '/' + parts[2] + '</span>&nbsp;&nbsp;<span class="tui-full-calendar-dayname-name">' + model.dayName + '</span>';
-                    // },
-                },
-            });
-            calendar.setDate(Date.parse(min_date));
-            calendar.createSchedules(events);
-            calendar.on({
-                'clickSchedule': function (e) {
-                    const s = e.schedule
-                    if (s.location.length > 0) {
-                        window.open(s.location, '_blanket');
-                    }
-                },
-            })
+      cal.setDate(day.toDate());
+      cal.createSchedules(events);
+      cal.on({
+        clickSchedule(e) {
+          const s = e.schedule;
+          if (s.location.length > 0) {
+            window.open(s.location, "_blanket");
+          }
+        },
+      });
 
-            all_cals.push(calendar);
+      all_cals.push(cal);
 
-            const cols = config.calendar.colors;
-            if (cols) {
-                const cals = [];
-                Object.keys(cols).forEach(k => {
-                    const v = cols[k];
-                    cals.push({
-                        id: k,
-                        name: k,
-                        bgColor: v,
-                    })
-                })
+      // console.log(week_dates.map(d => d.format()), "--- week_dates ");
 
-                calendar.setCalendars(cals);
+      //   const resize = async function (cal) {
+      //     await cal.render(true);
+      //     // d3.selectAll('.tui-full-calendar-vlayout-area').attr('style',null);
+      //   };
 
-            }
+      $(window).on(
+        "resize",
+        _.debounce(function () {
+          all_cals.forEach((c) => resize(c));
+        }, 100)
+      );
 
-
-            const week_dates = enumerateDaysBetweenDates(
-              calendar.getDateRangeStart().toDate(),
-              calendar.getDateRangeEnd().toDate())
-
-            const c_sm = d3.select('#calendar_small')
-            let i = 0
-            for (const day of week_dates) {
-                c_sm.append('div').attr('id', 'cal__' + i);
-                const cal = new Calendar('#cal__' + i, {
-                    defaultView: 'day',
-                    isReadOnly: true,
-                    // useDetailPopup: true,
-                    taskView: false,
-                    scheduleView: ['time'],
-                    usageStatistics: false,
-
-                    timezones: [{
-                        timezoneOffset: -moment.tz.zone(timezoneName)
-                          .utcOffset(moment(min_date)),
-                        displayLabel: timezoneName,
-                        tooltip: timezoneName
-                    }],
-                })
-
-                cal.setDate(day.toDate());
-                cal.createSchedules(events);
-                cal.on({
-                    'clickSchedule': function (e) {
-                        const s = e.schedule
-                        if (s.location.length > 0) {
-                            window.open(s.location, '_blanket');
-                        }
-                    },
-                })
-
-                all_cals.push(cal);
-                const cols = config.calendar.colors;
-                if (cols) {
-                    const cals = [];
-                    Object.keys(cols).forEach(k => {
-                        const v = cols[k];
-                        cals.push({
-                            id: k,
-                            name: k,
-                            bgColor: v,
-                        })
-                    })
-
-                    cal.setCalendars(cals);
-
-                }
-
-                i++;
-
-                // console.log(day.format(), "--- day");
-            }
-
-            // console.log(week_dates.map(d => d.format()), "--- week_dates ");
-
-
-            const resize = async function (cal) {
-                await cal.render(true);
-                // d3.selectAll('.tui-full-calendar-vlayout-area').attr('style',null);
-            }
-
-            $(window).on('resize', _.debounce(function () {
-                all_cals.forEach(c => resize(c));
-            }, 100));
-
-            // d3.selectAll('.tui-full-calendar-vlayout-area').attr('style',null);
-
-        })
-
-    })
-
+      // d3.selectAll('.tui-full-calendar-vlayout-area').attr('style',null);
+    });
+  });
 }

--- a/static/js/tutorial_calendar.js
+++ b/static/js/tutorial_calendar.js
@@ -1,0 +1,211 @@
+function make_cal(name) {
+
+    // console.log(location.search, "--- location.search");
+
+    const current_tz = getUrlParameter('tz') || moment.tz.guess();
+    const tzNames = [...moment.tz.names()];
+
+    const setupTZSelector = () => {
+        const tzOptons = d3.select('#tzOptions')
+        tzOptons.selectAll('option').data(tzNames)
+          .join('option')
+          .attr('data-tokens', d => d.split("/").join(" "))
+          .text(d => d)
+        $('.selectpicker')
+          .selectpicker('val', current_tz)
+          .on('changed.bs.select',
+            function (e, clickedIndex, isSelected, previousValue) {
+                new_tz = tzNames[clickedIndex]
+                window.open(window.location.pathname+'?tz='+new_tz, '_self');
+            })
+    }
+
+    setupTZSelector();
+
+    // requires moments.js
+    const enumerateDaysBetweenDates = function (startDate, endDate) {
+        const dates = [];
+
+        // console.log(startDate, endDate, "--- startDate, endDate");
+
+        const currDate = moment(startDate);
+        const lastDate = moment(endDate);
+
+        dates.push(currDate.clone());
+        while (currDate.add(1, 'days').diff(lastDate) < 0) {
+            // console.log(currDate, "--- currDate");
+            dates.push(currDate.clone());
+        }
+
+        dates.push(lastDate);
+        return dates;
+    };
+
+
+    $.get('serve_config.json').then(config => {
+        $.get(name).then(events => {
+
+            const all_cals = [];
+            const timezoneName = current_tz;
+
+            const min_date = d3.min(events.map(e => e.start));
+            var min_hours = d3.min(events.map(e => moment(e.start).tz(timezoneName).hours())) -1;
+            var max_hours = d3.max(events.map(e => moment(e.end).tz(timezoneName).hours())) +1;
+            if(min_hours < 0 || max_hours > 24) {
+                min_hours = 0;
+                max_hours = 24;
+            }
+            // console.log(min_hours, max_hours);
+            const Calendar = tui.Calendar;
+            const calendar = new Calendar('#calendar', {
+                defaultView: 'day',
+                isReadOnly: true,
+                // useDetailPopup: true,
+                taskView: false,
+                scheduleView: ['time'],
+                usageStatistics: false,
+                // week: {
+                //     workweek: !config.calendar["saturday"],
+                //     hourStart: min_hours,
+                //     hourEnd: max_hours
+                // },
+                timezones: [{
+                    timezoneOffset: -moment.tz.zone(timezoneName)
+                      .utcOffset(moment(min_date)),
+                    displayLabel: timezoneName,
+                    tooltip: timezoneName
+                }],
+                // timezones: [{
+                //     getTimezoneOffset: 540,
+                //     displayLabel: 'a',
+                //     tooltip: timezoneName
+                // }],
+                template: {
+                    // monthDayname: function (dayname) {
+                    //     return '<span class="calendar-week-dayname-name">' + dayname.label + '</span>';
+                    // },
+                    time: function (schedule) {
+                        return '<strong>' + moment(schedule.start.getTime())
+                          .tz(timezoneName)
+                          .format('hh:mm') + 
+                          '-' +
+                          moment(schedule.end.getTime())
+                          .tz(timezoneName)
+                          .format('hh:mm') + 
+                          '</strong> ' + schedule.title;
+                    },
+                    milestone: function (schedule) {
+                        return '<span class="calendar-font-icon ic-milestone-b"></span> <span style="background-color: ' + schedule.bgColor + '"> M: ' + schedule.title + '</span>';
+                    },
+                    // weekDayname: function (model) {
+                    //     const parts = model.renderDate.split('-');
+                    //     return '<span class="tui-full-calendar-dayname-name"> ' + parts[1] + '/' + parts[2] + '</span>&nbsp;&nbsp;<span class="tui-full-calendar-dayname-name">' + model.dayName + '</span>';
+                    // },
+                },
+            });
+            calendar.setDate(Date.parse(min_date));
+            calendar.createSchedules(events);
+            calendar.on({
+                'clickSchedule': function (e) {
+                    const s = e.schedule
+                    if (s.location.length > 0) {
+                        window.open(s.location, '_blanket');
+                    }
+                },
+            })
+
+            all_cals.push(calendar);
+
+            const cols = config.calendar.colors;
+            if (cols) {
+                const cals = [];
+                Object.keys(cols).forEach(k => {
+                    const v = cols[k];
+                    cals.push({
+                        id: k,
+                        name: k,
+                        bgColor: v,
+                    })
+                })
+
+                calendar.setCalendars(cals);
+
+            }
+
+
+            const week_dates = enumerateDaysBetweenDates(
+              calendar.getDateRangeStart().toDate(),
+              calendar.getDateRangeEnd().toDate())
+
+            const c_sm = d3.select('#calendar_small')
+            let i = 0
+            for (const day of week_dates) {
+                c_sm.append('div').attr('id', 'cal__' + i);
+                const cal = new Calendar('#cal__' + i, {
+                    defaultView: 'day',
+                    isReadOnly: true,
+                    // useDetailPopup: true,
+                    taskView: false,
+                    scheduleView: ['time'],
+                    usageStatistics: false,
+
+                    timezones: [{
+                        timezoneOffset: -moment.tz.zone(timezoneName)
+                          .utcOffset(moment(min_date)),
+                        displayLabel: timezoneName,
+                        tooltip: timezoneName
+                    }],
+                })
+
+                cal.setDate(day.toDate());
+                cal.createSchedules(events);
+                cal.on({
+                    'clickSchedule': function (e) {
+                        const s = e.schedule
+                        if (s.location.length > 0) {
+                            window.open(s.location, '_blanket');
+                        }
+                    },
+                })
+
+                all_cals.push(cal);
+                const cols = config.calendar.colors;
+                if (cols) {
+                    const cals = [];
+                    Object.keys(cols).forEach(k => {
+                        const v = cols[k];
+                        cals.push({
+                            id: k,
+                            name: k,
+                            bgColor: v,
+                        })
+                    })
+
+                    cal.setCalendars(cals);
+
+                }
+
+                i++;
+
+                // console.log(day.format(), "--- day");
+            }
+
+            // console.log(week_dates.map(d => d.format()), "--- week_dates ");
+
+
+            const resize = async function (cal) {
+                await cal.render(true);
+                // d3.selectAll('.tui-full-calendar-vlayout-area').attr('style',null);
+            }
+
+            $(window).on('resize', _.debounce(function () {
+                all_cals.forEach(c => resize(c));
+            }, 100));
+
+            // d3.selectAll('.tui-full-calendar-vlayout-area').attr('style',null);
+
+        })
+
+    })
+
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,7 +62,9 @@
 </div>
 <br/>
 <div class="row">
-    <p>Welcome to ACL2020! The conference comprises the following elements:</p>
+    <p>Welcome to ACL2020! The conference comprises of mainly two types of material: pre-recorded and live. 
+      You can watch the pre-recorded material anytime before or during the conference, whereas the live events have a fixed timing. 
+      Following are the main elements of the conference:</p>
     <dl>
       <dt>Schedule</dt>
       <dd>You can find the times for all the live sessions using the <a class="text-muted" href="calendar.html">Schedule</a>, where you can choose your timezone and 

--- a/templates/tutorial_cal_head.html
+++ b/templates/tutorial_cal_head.html
@@ -1,0 +1,24 @@
+<script src="https://cdn.jsdelivr.net/npm/ical.js@1.4.0/build/ical.min.js" integrity="sha256-iFbWWsVYU6rIgbq5wJc4mp8zvV3SkqupxgH/7a9PanY=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/moment@2.26.0/dist/moment.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/moment-timezone@0.5.31/builds/moment-timezone-with-data-10-year-range.min.js" integrity="sha256-Dx3P9LwbB/WuS+7Xv37Y+qcPS/14AwFH653Pw80AOhY=" crossorigin="anonymous"></script>
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="https://cdn.jsdelivr.net/npm/tui-calendar@1/dist/tui-calendar.min.css"
+/>
+
+<script src="https://cdn.jsdelivr.net/npm/tui-code-snippet@1.5.2/dist/tui-code-snippet.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/tui-dom@3.0.0/dist/tui-dom.min.js" integrity="sha256-Ha3QUAK/d/Z2BMN/hDoBjwP0Q0f5uS9MploTRSLqrLI=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/tui-calendar@1/dist/tui-calendar.min.js"></script>
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.10/dist/css/bootstrap-select.min.css"
+/>
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.10/dist/js/bootstrap-select.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/js-cookie@rc/dist/js.cookie.min.js"></script>
+
+<script src="static/js/lazy_load.js"></script>
+<script src="static/js/little_helpers.js"></script>
+<script type="text/javascript" src="static/js/tutorial_calendar.js"></script>

--- a/templates/tutorials.html
+++ b/templates/tutorials.html
@@ -13,10 +13,12 @@
     <!-- Tutorials -->
     <p>
       <b>
-      Below is the schedule of the tutorial to be held on Sunday, July 5th, 2020. 
+      Below is the schedule of the tutorial to be held on Sunday, July 5th, 2020. Click on each tutorial on the schedule to access its material. <br/><br/>
+
       Tutorials held in parallel are shown one besides the other in the calendar.  
-      Some tutorials are held twice and some are held once.
-      Click on the tutorial to get more information about it. 
+      Some tutorials are held twice and some are held once. 
+      Checkout <a href="https://acl2020.org/blog/intro-to-tutorial-infrastructure/">this blog post</a> by tutorial chairs to learn more about the new virtual format of tutorials.
+      
     </b>
     </p>
     <div class="tab-content py-3 px-3 px-sm-0" id="nav-tabContent">

--- a/templates/tutorials.html
+++ b/templates/tutorials.html
@@ -1,15 +1,55 @@
 {% set active_page = "Tutorials" %}
 {% set page_title = "Tutorials" %}
 {% extends "base.html" %}
+{% block head %}
+{{ super() }}
+{% include 'tutorial_cal_head.html' %}
+{% endblock %}
+
 
 {% block content %}
 <div class="tab-content py-3 px-3 px-sm-0" id="nav-tabContent">
   <div id="day">
     <!-- Tutorials -->
-    {{ components.section("Tutorials") }}
+    <p>
+      <b>
+      Below is the schedule of the tutorial to be held on Sunday, July 5th, 2020. 
+      Tutorials held in parallel are shown one besides the other in the calendar.  
+      Some tutorials are held twice and some are held once.
+      Click on the tutorial to get more information about it. 
+    </b>
+    </p>
+    <div class="tab-content py-3 px-3 px-sm-0" id="nav-tabContent">
+      <!-- Calender tab -->
+      <div
+        class="tab-pane active"
+        id="tab-calendar"
+        role="tabpanel"
+        aria-labelledby="nav-profile-tab"
+      >
+        <div class="form-group col">
+          <label for="tzOptions">Timezone:</label>
+          <select id="tzOptions" class="selectpicker" data-live-search="true">
+          </select>
+        </div>
+    
+        <!-- full cal for browser-->
+        <div id="calendar" class="d-none d-sm-block"></div>
+    
+        <!-- small cal for smart phones-->
+        <div id="calendar_small" class="d-sm-none"></div>
+    
+        <script type="text/javascript">
+          make_cal("serve_tutorial_calendar.json");
+        </script>
+      </div>
+    </div>
+    <!--
+    <br/>
     <div class="speakers">
       {{ components.tutorialgroup(tutorials) }}
     </div>
+    -->
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Updated the main tutorials page in a way that the tutorials are displayed in the form of a schedule. This was a request by the tutorial organizers to be posted on the acl2020.org website. But since we couldn't do it there, I thought we should display it in this way atleast on the virtual website. 

Here is the doc shared with us by the tutorial organizers that I used to create the schedule: https://docs.google.com/spreadsheets/d/1AGp925GVUkSsJ9U-02WXLG1euVxoEIc1rKUPv1P10g4/edit#gid=936853935