### PR TITLE
Improved Home Page layout

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,51 +30,9 @@
 {% block content %}
 
 <div class="row">
-  <div class="col-md-4 col-sm-12">
-    <dt>Welcome Message from General Chair and Program Chairs</dt><br/>
-    <div id="presentation-embed" class="slp embed-responsive embed-responsive-16by9"></div>
-    <script src='https://slideslive.com/embed_presentation.js'></script>
-    <script>
-      embed = new SlidesLiveEmbed('presentation-embed', {
-      presentationId: '{{config.default_presentation_id}}',
-      autoPlay: false, // change to true to autoplay the embedded presentation
-      verticalEnabled: true,
-      verticalWhenWidthLte: 2000,
-      allowHiddenControlsWhenPaused: true,
-      hideTitle: true
-      });
-    </script>
-  </div>
-  <div class="col-md-4 col-sm-12">
-    <dt>Message from Virtual Infrastructure Chairs about the virtual conference website</dt><br/>
-    <div id="presentation-embed-2" class="slp embed-responsive embed-responsive-16by9"></div>
-    <script src='https://slideslive.com/embed_presentation.js'></script>
-    <script>
-      embed = new SlidesLiveEmbed('presentation-embed-2', {
-      presentationId: '{{config.default_presentation_id}}',
-      autoPlay: false, // change to true to autoplay the embedded presentation
-      verticalEnabled: true,
-      verticalWhenWidthLte: 2000,
-      allowHiddenControlsWhenPaused: true,
-      hideTitle: true
-      });
-    </script>
-  </div>  
-  <div class="col-md-4 col-sm-12 text-center">
-    <h3>Announcements</h3>
-    <div class="col-md-12 col-xs-12 p-2">
-    <div id="gitter" class="slp">
-    <center>
-      <iframe frameborder="0" src="https://{{config.chat_server}}/channel/announcements?layout=embedded" height="500px" width="100%" ></iframe>
-    </center>
-    </div>
-    </div>
-
-  </div>
-</div>
-<br/>
-<div class="row lead">
-    <p>Welcome to ACL2020! The conference comprises of mainly two types of material: pre-recorded and live.
+  <div class="col-md-7 col-sm-12 pr-5 lead">
+    <p>Welcome to ACL2020!<br><br>
+      The conference comprises of mainly two types of material: pre-recorded and live.
       You can watch the pre-recorded material anytime before or during the conference, whereas the live events have a fixed timing. 
       Following are the main elements of the conference:</p>
     <dl>
@@ -109,7 +67,55 @@
       <dt> Social Media</dt>
       <dd> Share papers,  workshops, and demos by using the hashtag  <span style="font-weight: bold; font-family: 'Consolas', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace;">#ACL2020</span></dd>
     </dl>
+  </div>
+  <!-- <div class="col-md-1"></div> -->
+  <div class="col-md-5 col-sm-12">
+    <div class="text-center mt-4">
+      <h5>A Message from the General <br> Chair and Program Chairs</h5>
+      <div id="presentation-embed" class="mt-3 slp embed-responsive embed-responsive-16by9">
+        <script src='https://slideslive.com/embed_presentation.js'></script>
+        <script>
+          embed = new SlidesLiveEmbed('presentation-embed', {
+          presentationId: '{{config.default_presentation_id}}',
+          autoPlay: false, // change to true to autoplay the embedded presentation
+          verticalEnabled: true,
+          verticalWhenWidthLte: 2000,
+          allowHiddenControlsWhenPaused: true,
+          hideTitle: true
+          });
+        </script>
+      </div>
+    </div>
+    <div class="text-center mt-4">
+      <h5>Announcements</h5>
+      <div class="col-md-12 col-xs-12">
+        <div id="gitter" class="slp">
+          <center>
+            <iframe frameborder="0" src="https://{{config.chat_server}}/channel/announcements?layout=embedded" height="500px" width="100%" ></iframe>
+          </center>
+        </div>
+      </div>
+    </div>
+    <div class="text-center mt-4">
+      <h5> About the virtual <br> conference website</h5>
+      <div id="presentation-embed-2" class="slp embed-responsive embed-responsive-16by9">
+        <script src='https://slideslive.com/embed_presentation.js'></script>
+        <script>
+          embed = new SlidesLiveEmbed('presentation-embed-2', {
+          presentationId: '{{config.default_presentation_id}}',
+          autoPlay: false, // change to true to autoplay the embedded presentation
+          verticalEnabled: true,
+          verticalWhenWidthLte: 2000,
+          allowHiddenControlsWhenPaused: true,
+          hideTitle: true
+          });
+        </script>
+      </div>
+    </div>  
+  </div>
 </div>
+<br/>
+
 
 <!-- Organizers -->
 {{ components.section("Organizers") }}


### PR DESCRIPTION
I've played around with the layout quite a bit and these are the changes I ended up with:
- adopt 2 column layout similar to https://iclr.cc/virtual_2020/
- increased video sizes
- made video titles more concise
- fix stray divs and make slideslive embeds properly responsive
Relevant issues: #19, #169 

I still need to make some minor spacing tweaks etc. but will proceed if the basic design is okay.
Some questions:
- Will the video messages be using slides? By default, slideslive embed only shows the video view.
If they use slides, I'll either have to tweak the embed to open in full-screen upon click to see the video and slides side-by-side or make the videos and slides full-width. On a related note, can anyone link to slideslive documentation? I couldn't find details on the embed params anywhere...
- I found the font size a bit too big. Is this intentional or can I make it smaller, say to the scale of the ICLR page?
 
![screenshot-localhost-5000-index-html-1592982237654](https://user-images.githubusercontent.com/58948612/85512162-9455ed00-b5c7-11ea-8de3-5efb8df1034b.png)
