### PR TITLE
Add script to get users from AWS Cognito User Pool

### DIFF
--- a/awscognito/README.md
+++ b/awscognito/README.md
@@ -21,10 +21,12 @@ reset their passwords.
 python cognito_users.py user.csv aws_profile.yml
 ```
 
-* To disable user(s) from .xlsx or .csv file.
+* To check/disable/enable user(s) from .xlsx or .csv file.
 
 ```bash
+python cognito_users.py --check user.csv aws_profile.yml
 python cognito_users.py -d user.csv aws_profile.yml
+python cognito_users.py -e user.csv aws_profile.yml
 ```
 
 * Get help message of using cognito_users.py
@@ -32,4 +34,24 @@ python cognito_users.py -d user.csv aws_profile.yml
 ```bash
 python cognito_users.py -h
 ```
+
+* Create dry run user(s) from .xlsx or .csv file.  This will set `email_verified` to true as well
+```bash
+python dry_run_users.py user.csv aws_profile.yml
+```
+
+* To check/disable/enable user(s) from .xlsx or .csv file.
+
+```bash
+python dry_run_users.py --check user.csv aws_profile.yml
+python dry_run_users.py -d user.csv aws_profile.yml
+python dry_run_users.py -e user.csv aws_profile.yml
+```
+
+* Get help message of using dry_run_users.py
+
+```bash
+python cognito_users.py -h
+```
+
 .

--- a/awscognito/cognito_list.py
+++ b/awscognito/cognito_list.py
@@ -1,0 +1,106 @@
+# pylint: disable=global-statement,redefined-outer-name
+""" Script used to list AWS Cognito users """
+import argparse
+import sys
+from dataclasses import asdict, dataclass
+
+import boto3
+import pandas
+import yaml
+
+
+@dataclass(frozen=True)
+class User:
+    """ Class for AWS Cognito user """
+
+    email: str
+    name: str
+    committee: str = "attendee"
+
+    # def name(self) -> str:
+    #     """ Generate the name field """
+    #     return f"{self.first_name} {self.last_name}"
+
+
+def list_users(client, profile):
+    """ Deletes a user from the pool """
+    try:
+        response = client.list_users(
+            UserPoolId=profile["user_pool_id"],
+            # AttributesToGet=['email']
+        )
+        if response["ResponseMetadata"]["HTTPStatusCode"] == 200:
+            print("Get Users successfully")
+            return response["Users"]
+
+    except client.exceptions.ClientError as error:
+        print("Fail to list users")
+        print(error)
+        sys.exit(2)
+
+    return []
+
+
+def load_data(aws_profile, is_debug=False):
+    """ Load the profile data and get pool user """
+    profile = yaml.load(open(aws_profile).read(), Loader=yaml.SafeLoader)
+
+    # Prepare the AWS client
+    client = boto3.client(
+        "cognito-idp",
+        aws_access_key_id=profile["access_key_id"],
+        aws_secret_access_key=profile["secret_access_key"],
+        region_name=profile["region_name"],
+    )
+    aws_users = list_users(client, profile)
+    result = []
+    for aws_user in aws_users:
+        email: str = ""
+        name: str = ""
+        enabled = aws_user["Enabled"]
+
+        # We assume all users with 'custom:name' attribute is created by our scripts
+        for attr in aws_user["Attributes"]:
+            attr_name = attr["Name"]
+            if attr_name == "email":
+                email = attr["Value"]
+            elif attr_name == "custom:name":
+                name = attr["Value"]
+
+        if name:
+            if is_debug:
+                print(f"user: {name} <{email}>, enabled: {enabled}")
+            result.append(User(name=name, email=email))
+
+    return result
+
+
+def parse_arguments():
+    """ Parse Arguments """
+    parser = argparse.ArgumentParser(
+        description="AWS Cognito List Command Line",
+        # usage="cognito_user.py [-h] aws_profile",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Show the users is enabled or not",
+    )
+    parser.add_argument("aws_profile", help="The file contains AWS profile")
+
+    return parser.parse_args()
+
+
+def save_file(users, file_path):
+    """ Save user information to the xlsx file """
+    dataframe = pandas.DataFrame([asdict(x) for x in users])
+    dataframe.to_excel(file_path)
+    print(f"User information is written to {file_path}")
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    users = load_data(args.aws_profile, args.debug)
+
+    save_file(users, "all_users.xlsx")

--- a/awscognito/dry_run_sample.csv
+++ b/awscognito/dry_run_sample.csv
@@ -1,0 +1,3 @@
+﻿name,email,committee
+Jane Doe,jane.doe@gmail.com,attendee
+John Doe,john.doe@gmail.com,attendee

--- a/awscognito/dry_run_users.py
+++ b/awscognito/dry_run_users.py
@@ -14,18 +14,13 @@ import yaml
 class User:
     """ Class for AWS Cognito user """
 
-    first_name: str
-    last_name: str
     email: str
-    middle_name: str = ""
-    preferred_name: str = ""
-    affiliation: str = ""
-    timezone: str = ""
-    country: str = ""
+    name: str
+    committee: str = ""
 
-    def name(self) -> str:
-        """ Generate the name field """
-        return f"{self.first_name} {self.last_name}"
+    # def name(self) -> str:
+    #     """ Generate the name field """
+    #     return f"{self.first_name} {self.last_name}"
 
 
 def create_user(client, profile, user):
@@ -37,7 +32,7 @@ def create_user(client, profile, user):
             UserAttributes=[
                 {"Name": "email", "Value": user.email},
                 {"Name": "email_verified", "Value": "true"},
-                {"Name": "custom:name", "Value": user.name()},
+                {"Name": "custom:name", "Value": user.name},
             ],
         )
         if response["ResponseMetadata"]["HTTPStatusCode"] == 200:
@@ -178,11 +173,13 @@ def parse_file(path):
         error_message = f"File {path} is not supported"
 
     if has_error is False:
+        # Change column headers to lowercase
+        dataframe.columns = map(str.lower, dataframe.columns)
+
         # Check invalid rows/records
-        no_last_name = dataframe["last_name"].isnull()
-        no_first_name = dataframe["first_name"].isnull()
         no_email = dataframe["email"].isnull()
-        invalid_rows = dataframe.loc[no_last_name | no_first_name | no_email]
+        no_name = dataframe["name"].isnull()
+        invalid_rows = dataframe.loc[no_name | no_email]
         if len(invalid_rows.index) == 0:
             # No invalid records.  Let's go ahead
             users = [User(**kwargs) for kwargs in dataframe.to_dict(orient="records")]

--- a/awscognito/requirements.txt
+++ b/awscognito/requirements.txt
@@ -4,3 +4,4 @@ boto3
 # Required for handling both xlsx and csv file
 pandas
 xlrd >= 1.0.0
+openpyxl


### PR DESCRIPTION
- Add script `cognito_list.py` to get all users (with attribute 'custom:name') from AWS Cognito User Pool
- Add enable_user to script `cognito_users.py`
- Add script `dry_run_users.py` to create dry run users with different Excel format