### PR TITLE
Feature/208 rocket chat channel scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,6 @@ node_modules/
 # MacOS
 .DS_Store
 
-# RocketChat credentials
+# RocketChat credentials and output files
 chat/config.yml
+chat/channels.csv

--- a/chat/README.md
+++ b/chat/README.md
@@ -55,6 +55,13 @@ https://forums.rocket.chat/t/anyone-auth0-sso-experience/2060/6
 
 `make_poster_rooms.py` -> for creating a chat room for each poster.
 
+`list_channels.py` -> for exporting channels into a CSV with regex name search and a `featured` filter (see CLI options). For example, for featured channels not containing the word `paper`:
+
+```bash
+python list_channels.py -r '^((?!paper).)*$' -f -o channels.csv 
+```
+
+In order to run the scripts, make sure to create the `chat/config.yml` file as described below.
 
 ## Chat Server Configuration (config.yml - Don't check in)
 

--- a/chat/list_channels.py
+++ b/chat/list_channels.py
@@ -1,33 +1,52 @@
 import argparse
 import json
-import pprint
-from typing import Dict, List, Union, Any
+from typing import Any, Dict, List
 
-from tqdm import tqdm
-import yaml
 import pandas as pd
+import yaml
 from requests import sessions
 from rocketchat_API.rocketchat import RocketChat
+from tqdm import tqdm
 
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description="MiniConf Portal Command Line")
-    parser.add_argument("--config", "-c", default="./config.yml", 
-                        help="Configuration yaml filepath. Default: ./config.yml")
-    parser.add_argument("--output_file", "-o", default="channels.csv", 
-                        help="Output csv filepath. Default: ./channels.csv")
-    parser.add_argument("--regexp", "--regex", "-r", default=None,
-                        help="Regular expression for filtering channels by name")
-    parser.add_argument("--filter_featured", '--featured', '-f', action="store_true",
-                        help="Output only featured channels")
+    parser.add_argument(
+        "--config",
+        "-c",
+        default="./config.yml",
+        help="Configuration yaml filepath. Default: ./config.yml",
+    )
+    parser.add_argument(
+        "--output_file",
+        "-o",
+        default="channels.csv",
+        help="Output csv filepath. Default: ./channels.csv",
+    )
+    parser.add_argument(
+        "--regexp",
+        "--regex",
+        "-r",
+        default=None,
+        help="Regular expression for filtering channels by name",
+    )
+    parser.add_argument(
+        "--filter_featured",
+        "--featured",
+        "-f",
+        action="store_true",
+        help="Output only featured channels",
+    )
     return parser.parse_args()
 
 
 def postprocess(channels: pd.DataFrame) -> pd.DataFrame:
     if "t" in channels:
         channel_types = {
-            "d": "Direct chat", "c": "Chat",
-            "p": "Private chat", "l": "Livechat"
+            "d": "Direct chat",
+            "c": "Chat",
+            "p": "Private chat",
+            "l": "Livechat",
         }
         channels.rename(columns={"t": "channelType"}, inplace=True)
         channels["channelType"] = channels["channelType"].map(channel_types)
@@ -41,8 +60,7 @@ def postprocess(channels: pd.DataFrame) -> pd.DataFrame:
     return channels
 
 
-def get_params(filter_featured: bool = False, 
-               regexp: str = None) -> Dict[str, str]:
+def get_params(filter_featured: bool = False, regexp: str = None) -> Dict[str, str]:
     # t: channel type (d: Direct chat, c: Chat, p: Private chat, l: Livechat)
     # msgs: number of messages
     fields = ["name", "msgs", "usersCount", "featured", "t", "topic", "_updatedAt"]
@@ -52,10 +70,10 @@ def get_params(filter_featured: bool = False,
         query["featured"] = True
     if regexp is not None:
         query["name"] = {"$regex": regexp}
-        
+
     params = {
         "fields": json.dumps({f: True for f in fields}),
-        "query": json.dumps(query)
+        "query": json.dumps(query),
     }
     return params
 
@@ -69,12 +87,12 @@ if __name__ == "__main__":
             user_id=config["user_id"],
             auth_token=config["auth_token"],
             server_url=config["server"],
-            session=session
+            session=session,
         )
-        params = get_params(args.filter_featured, args.regexp)
+        channels_params = get_params(args.filter_featured, args.regexp)
 
         channels_list: List[Dict] = []
-        channels_json = rocket.channels_list(**params).json()
+        channels_json = rocket.channels_list(**channels_params).json()
         channels_list.extend(channels_json["channels"])
 
         count, total = 50, channels_json["total"]
@@ -82,8 +100,9 @@ if __name__ == "__main__":
 
         for offset in tqdm(range(count, total, count)):
             channels_json = rocket.channels_list(
-                offset=offset, count=count, **params).json()
+                offset=offset, count=count, **channels_params
+            ).json()
             channels_list.extend(channels_json["channels"])
 
-        channels = postprocess(pd.DataFrame(channels_list))
-        channels.to_csv(args.output_file, index=False)
+        channels_df = postprocess(pd.DataFrame(channels_list))
+        channels_df.to_csv(args.output_file, index=False)

--- a/chat/list_channels.py
+++ b/chat/list_channels.py
@@ -1,0 +1,89 @@
+import argparse
+import json
+import pprint
+from typing import Dict, List, Union, Any
+
+from tqdm import tqdm
+import yaml
+import pandas as pd
+from requests import sessions
+from rocketchat_API.rocketchat import RocketChat
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="MiniConf Portal Command Line")
+    parser.add_argument("--config", "-c", default="./config.yml", 
+                        help="Configuration yaml filepath. Default: ./config.yml")
+    parser.add_argument("--output_file", "-o", default="channels.csv", 
+                        help="Output csv filepath. Default: ./channels.csv")
+    parser.add_argument("--regexp", "--regex", "-r", default=None,
+                        help="Regular expression for filtering channels by name")
+    parser.add_argument("--filter_featured", '--featured', '-f', action="store_true",
+                        help="Output only featured channels")
+    return parser.parse_args()
+
+
+def postprocess(channels: pd.DataFrame) -> pd.DataFrame:
+    if "t" in channels:
+        channel_types = {
+            "d": "Direct chat", "c": "Chat",
+            "p": "Private chat", "l": "Livechat"
+        }
+        channels.rename(columns={"t": "channelType"}, inplace=True)
+        channels["channelType"] = channels["channelType"].map(channel_types)
+
+    if "msgs" in channels:
+        channels.rename(columns={"msgs": "messagesCount"}, inplace=True)
+
+    if "_updatedAt" in channels:
+        channels.rename(columns={"_updatedAt": "lastUpdate"}, inplace=True)
+
+    return channels
+
+
+def get_params(filter_featured: bool = False, 
+               regexp: str = None) -> Dict[str, str]:
+    # t: channel type (d: Direct chat, c: Chat, p: Private chat, l: Livechat)
+    # msgs: number of messages
+    fields = ["name", "msgs", "usersCount", "featured", "t", "topic", "_updatedAt"]
+
+    query: Dict[str, Any] = {}
+    if filter_featured:
+        query["featured"] = True
+    if regexp is not None:
+        query["name"] = {"$regex": regexp}
+        
+    params = {
+        "fields": json.dumps({f: True for f in fields}),
+        "query": json.dumps(query)
+    }
+    return params
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    config = yaml.load(open(args.config), Loader=yaml.SafeLoader)
+
+    with sessions.Session() as session:
+        rocket = RocketChat(
+            user_id=config["user_id"],
+            auth_token=config["auth_token"],
+            server_url=config["server"],
+            session=session
+        )
+        params = get_params(args.filter_featured, args.regexp)
+
+        channels_list: List[Dict] = []
+        channels_json = rocket.channels_list(**params).json()
+        channels_list.extend(channels_json["channels"])
+
+        count, total = 50, channels_json["total"]
+        print(f"Found {total} channels")
+
+        for offset in tqdm(range(count, total, count)):
+            channels_json = rocket.channels_list(
+                offset=offset, count=count, **params).json()
+            channels_list.extend(channels_json["channels"])
+
+        channels = postprocess(pd.DataFrame(channels_list))
+        channels.to_csv(args.output_file, index=False)

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,6 +10,6 @@ ignore_missing_imports = True
 [mypy-boto3.*]
 ignore_missing_imports = True
 
-[mypy-rocketchat_API.*]
+[mypy-rocketchat_API.*,tqdm.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Added the `list_channels.py` script (https://github.com/acl-org/acl-2020-virtual-conference/issues/208) for listing channels from RocketChat into a CSV file with regex channel name filtering and featured channel filtering options documented in the CLI help, as also described in the chat/README.md file.