### PR TITLE
#206 - Display paper types (Long/Short/CL/TACL)

### DIFF
--- a/miniconf/load_site_data.py
+++ b/miniconf/load_site_data.py
@@ -351,6 +351,7 @@ def build_papers(
                 pdf_url=item.get("pdf_url", ""),
                 demo_url=item.get("demo_url", ""),
                 track=normalize_track_name(item.get("track", "")),
+                paper_type=item.get("paper_type", ""),
                 sessions=sessions_for_paper[item["UID"]],
                 similar_paper_uids=paper_recs.get(item["UID"], [item["UID"]]),
             ),

--- a/miniconf/site_data.py
+++ b/miniconf/site_data.py
@@ -35,6 +35,7 @@ class PaperContent:
     title: str
     authors: List[str]
     track: str
+    paper_type: str
     abstract: str
     tldr: str
     keywords: List[str]

--- a/templates/paper.html
+++ b/templates/paper.html
@@ -58,6 +58,7 @@
      <p class="card-text text-center h5">
 
      <a href="papers.html?track={{paper.content.track}}" class ="badge badge-pill badge-primary">{{ paper.content.track }}</a>
+     <span class="badge badge-secondary">{{ paper.content.paper_type }}</span>
     </p>
 
     <div class="text-center text-muted text-monospace paper-detail-container">


### PR DESCRIPTION
Covers:
- Display the paper type in the paper view
  - show white text in a gray rectangle next to the track information