### PR TITLE
minor fix: papers detail styling

### DIFF
--- a/static/js/papers.js
+++ b/static/js/papers.js
@@ -228,7 +228,7 @@ const card_image = (openreview, show) => {
 const card_detail = (openreview, show) => {
     if (show)
         return ` 
-     <div class="pp-card-header">
+     <div class="pp-card-header" style="height:220px;background-color:rgb(240, 240, 240)">
         <p class="card-text"> ${openreview.content.tldr}</p>
         <!--<p class="card-text"><span class="font-weight-bold">Keywords:</span>
             ${openreview.content.keywords.map(keyword).join(', ')}
@@ -242,7 +242,10 @@ const card_detail = (openreview, show) => {
 const card_html = openreview => `
         <div class="pp-card pp-mode-` + render_mode + ` ">
             <div class="pp-card-header">
-            <div class="checkbox-paper ${openreview.content.read ? 'selected' : ''}" style="display: block;position: absolute; bottom:35px;left: 35px;">✓</div>    
+            <div class="" style="position: relative; height:340px">
+                <div style="display: block;position: absolute; bottom:35px;left: 0px;">
+                    <div class="checkbox-paper ${openreview.content.read ? 'selected' : ''}">✓</div>
+                </div>
                 <a href="paper_${openreview.id}.html"
                 target="_blank"
                    class="text-muted">
@@ -251,7 +254,7 @@ const card_html = openreview => `
                         ${openreview.content.authors.join(', ')}
                 </h6>
                 ${card_image(openreview, render_mode !== 'list')}
-                
+            </div>
             </div>
                
                 ${card_detail(openreview, (render_mode === 'detail'))}


### PR DESCRIPTION
Fixing the height of the papers detail panel (340px -> 220px) (tested on several media sizes). Also, contrast background for easy reading.