### PR TITLE
#269 Papers/Vis: Keyword search

### DIFF
--- a/static/js/papers.js
+++ b/static/js/papers.js
@@ -262,9 +262,9 @@ const card_detail = (openreview, show) => {
         return ` 
      <div class="pp-card-header" style="height:220px;background-color:rgb(240, 240, 240)">
         <p class="card-text"> ${openreview.content.tldr}</p>
-        <!--<p class="card-text"><span class="font-weight-bold">Keywords:</span>
+        <p class="card-text"><span class="font-weight-bold">Keywords:</span>
             ${openreview.content.keywords.map(keyword).join(', ')}
-        </p>-->
+        </p>
     </div>
 `
     else return ''

--- a/templates/papers.html
+++ b/templates/papers.html
@@ -74,20 +74,18 @@
         <input type="radio" name="options" value="titles" autocomplete="off" checked />
         by title
       </label>
-      <!--
-    <label
-      class="btn btn-outline-secondary"
-      data-tippy-content="Search for papers with specific keywords"
-    >
-      <input
-        type="radio"
-        name="options"
-        value="keywords"
-        autocomplete="off"
-      />
-      keyword
-    </label>
-    -->
+      <label
+        class="btn btn-outline-secondary"
+        data-tippy-content="Search for papers with specific keywords"
+      >
+        <input
+          type="radio"
+          name="options"
+          value="keywords"
+          autocomplete="off"
+        />
+        keyword
+      </label>
       <label class="btn btn-outline-primary" data-tippy-content="Search for papers from specific authors">
         <input type="radio" name="options" value="authors" autocomplete="off" />
         by author

--- a/templates/papers_vis.html
+++ b/templates/papers_vis.html
@@ -59,20 +59,18 @@
         <input type="radio" name="options" value="titles" autocomplete="off"/>
         by title
       </label>
-      <!--
-    <label
-      class="btn btn-outline-secondary"
-      data-tippy-content="Search for papers with specific keywords"
-    >
-      <input
-        type="radio"
-        name="options"
-        value="keywords"
-        autocomplete="off"
-      />
-      keyword
-    </label>
-    -->
+      <label
+        class="btn btn-outline-secondary"
+        data-tippy-content="Search for papers with specific keywords"
+      >
+        <input
+          type="radio"
+          name="options"
+          value="keywords"
+          autocomplete="off"
+        />
+        keyword
+      </label>
       <label class="btn btn-outline-primary" data-tippy-content="Search for papers from specific authors">
         <input type="radio" name="options" value="authors" autocomplete="off" checked />
         by author


### PR DESCRIPTION
Covers:

Enable searching papers by keywords in "Browse" and "Visualization" views
  - Also display keywords in the right sidebar results

Linked issue: https://github.com/acl-org/acl-2020-virtual-conference/issues/269
Linked PR: https://github.com/acl-org/acl-2020-virtual-conference-sitedata/pull/101