### PR TITLE
#430: Add Tutorial Worksheet link to T7

### DIFF
--- a/templates/tutorial.html
+++ b/templates/tutorial.html
@@ -84,11 +84,18 @@
   <b>Information about the virtual format of this tutorial: </b> {{tutorial.virtual_format_description}}
   <br/>
   {% if tutorial.id == 'T1' %}
-  <div class="row m-2">
+  <div class="row m-2" style="padding-left: 5px;">
     <a href="https://www.dory.app/c/google.com/aaabb999_acl-20-interpretability-tutorial/questions" target="_blank"  class="card-link">
        Question and discussion topic collection via Dory
     </a>
   </div>
+  {% elif tutorial.id == 'T7' %}
+  <div class="row m-2" style="padding-left: 5px;">
+    <a href="https://docs.google.com/document/d/1WUerIY4MKuKEmvWR2OeB_oJCSBl3k4Q7KWwNzm5HYhs/view" target="_blank" class="card-link">
+       Tutorial Worksheet
+    </a>
+  </div>
+
   {% endif %}
   <script src="static/js/time-extend.js"></script>
   <script>


### PR DESCRIPTION
Covers:
Add Tutorial Worksheet link to Tutorial T7
  - align link text to subheader below it

Linked issue: https://github.com/acl-org/acl-2020-virtual-conference/issues/430
<img width="1014" alt="Screen Shot 2020-07-03 at 10 45 03 PM" src="https://user-images.githubusercontent.com/3663322/86503751-ee507280-bd7e-11ea-8528-3f2d4a90ac33.png">
