### PR TITLE
use a separate repo to host paper images

### DIFF
--- a/miniconf/load_site_data.py
+++ b/miniconf/load_site_data.py
@@ -376,11 +376,7 @@ def normalize_track_name(track_name: str) -> str:
 
 
 def get_card_image_path_for_paper(paper_id: str, paper_images_path: str) -> str:
-    if os.path.exists(os.path.join(paper_images_path, f"{paper_id}.png")):
-        return f"{paper_images_path}/{paper_id}.png"
-    else:
-        # print(f"WARNING: using default image for {paper_id}")
-        return f"{paper_images_path}/default.png"
+    return f"{paper_images_path}/{paper_id}.png"
 
 
 def build_papers(

--- a/static/js/papers.js
+++ b/static/js/papers.js
@@ -12,7 +12,7 @@ const filters = {
     title: null,
 };
 
-let render_mode = 'compact';
+let render_mode = 'list';
 
 const persistor = new Persistor('Mini-Conf-Papers');
 

--- a/templates/papers.html
+++ b/templates/papers.html
@@ -108,13 +108,22 @@
 
     <label class="btn btn-outline-secondary active">
       <input
+          type="radio"
+          name="options"
+          value="list"
+          autocomplete="off"
+          checked
+      />
+      compact
+    </label>
+    <label class="btn btn-outline-secondary">
+      <input
         type="radio"
         name="options"
         value="compact"
         autocomplete="off"
-        checked
       />
-      compact
+      medium
     </label>
     <label class="btn btn-outline-secondary">
       <input


### PR DESCRIPTION
Fixes #468 and #415 .
* Now all images are moved to https://github.com/acl-org/acl-2020-virtual-conference-images and deployed at a public S3 bucket. In this way we can always update the images without updating the main website.
* Also added back the list view but renamed them to `compact/medium/detail`.

![image](https://user-images.githubusercontent.com/9957482/86526370-39828800-be48-11ea-8058-9ae27c44b009.png)
