### PR TITLE
Update script to display socials in local timezone

### DIFF
--- a/static/js/time-extend.js
+++ b/static/js/time-extend.js
@@ -1,19 +1,13 @@
 add_local_tz = (selector) => {
   const regex_time = new RegExp("\\((.*)-(.*) (.*)\\)");
   const guess_tz = moment.tz.guess(true);
-  const utc_offsets = { UTC: 0, GMT: 0, PDT: -7 };
 
   $(selector).each(function () {
     const t = $(this).text();
     const res = regex_time.exec(t);
-    if (res && res[3] in utc_offsets) {
-      const utc_offset = utc_offsets[res[3]];
-      const start_time = moment
-        .utc(`2020-07-05 ${res[1]}`)
-        .utcOffset(utc_offset, true);
-      const end_time = moment
-        .utc(`2020-07-05 ${res[2]}`)
-        .utcOffset(utc_offset, true);
+    if (res) {
+      const start_time = moment.utc(`2020-07-05 ${res[1]}`);
+      const end_time = moment.utc(`2020-07-05 ${res[2]}`);
       const local_start = moment(start_time).tz(guess_tz);
       const local_start_and_tz = local_start.format("HH:mm");
       const local_end = moment(end_time).tz(guess_tz);

--- a/static/js/time-extend.js
+++ b/static/js/time-extend.js
@@ -1,23 +1,29 @@
 add_local_tz = (selector) => {
   const regex_time = new RegExp("\\((.*)-(.*) (.*)\\)");
   const guess_tz = moment.tz.guess(true);
+  const utc_offsets = { UTC: 0, GMT: 0, PDT: -7 };
 
   $(selector).each(function () {
     const t = $(this).text();
     const res = regex_time.exec(t);
-    if (res) {
-      const start_time = moment.utc(`2020-07-05 ${res[1]}`);
-      const end_time = moment.utc(`2020-07-05 ${res[2]}`);
-      const local_start = start_time.tz(guess_tz);
-      const local_start_and_tz = start_time.format("HH:mm");
-      const local_end = end_time.tz(guess_tz);
+    if (res && res[3] in utc_offsets) {
+      const utc_offset = utc_offsets[res[3]];
+      const start_time = moment
+        .utc(`2020-07-05 ${res[1]}`)
+        .utcOffset(utc_offset, true);
+      const end_time = moment
+        .utc(`2020-07-05 ${res[2]}`)
+        .utcOffset(utc_offset, true);
+      const local_start = moment(start_time).tz(guess_tz);
+      const local_start_and_tz = local_start.format("HH:mm");
+      const local_end = moment(end_time).tz(guess_tz);
       const local_end_and_tz = local_end.format("HH:mm z");
       let end_dd;
       if (start_time.isAfter(end_time)) {
         // needs to deal with "Jul 5 (22:00-01:30 GMT)", where the end time is actually +1d
-        end_dd = local_end.dayOfYear() - (end_time.utc().dayOfYear() - 1);
+        end_dd = local_end.dayOfYear() - (end_time.dayOfYear() - 1);
       } else {
-        end_dd = local_end.dayOfYear() - end_time.utc().dayOfYear();
+        end_dd = local_end.dayOfYear() - end_time.dayOfYear();
       }
       let end_dd_str = "";
       if (end_dd > 0) {

--- a/templates/socials.html
+++ b/templates/socials.html
@@ -15,4 +15,11 @@
     </div>
   </div>
 </div>
+
+<script src="static/js/time-extend.js"></script>
+<script>
+  $(document).ready(()=>{
+    add_local_tz('.session_times');
+  })
+</script>
 {% endblock %}


### PR DESCRIPTION
Script needed an update as it assumes the base time given is UTC, but socials are given in PDT. 

Socials:
![Screenshot_2020-07-05 ACL2020 Socials](https://user-images.githubusercontent.com/1337259/86535646-af82ff80-bed9-11ea-9a43-c1f99126fb23.png)
Workshop (no change from [current](https://virtual.acl2020.org/workshop_W18.html)):
![Screenshot_2020-07-05 ACL2020 W18 Automatic Simultaneous Translation (AutoSimTrans)](https://user-images.githubusercontent.com/1337259/86535636-9da15c80-bed9-11ea-9c40-d2efe85adae8.png)
Paper 1 (no change from [current](https://virtual.acl2020.org/paper_main.557.html)):
![Screenshot_2020-07-05 ACL2020 Tetra-Tagging Word-Synchronous Parsing with Linear-Time Inference](https://user-images.githubusercontent.com/1337259/86535637-9e39f300-bed9-11ea-896a-9d92d5c7df30.png)
Paper 2 (no change from [current](https://virtual.acl2020.org/paper_main.642.html))
![image](https://user-images.githubusercontent.com/1337259/86535770-acd4da00-beda-11ea-8526-8e39a6106b2b.png)
Tutorial (no change from [current](https://virtual.acl2020.org/tutorial_T1.html)):
![Screenshot_2020-07-05 ACL2020 Interpretability and Analysis in Neural NLP](https://user-images.githubusercontent.com/1337259/86535638-9f6b2000-bed9-11ea-93b5-28a83ff47b1c.png)
