### PR TITLE
Add conditional for workshop event with only start time & bump sitedata

### DIFF
--- a/templates/workshop.html
+++ b/templates/workshop.html
@@ -63,8 +63,12 @@
       </thead>
       <tbody>
         {% for event in workshop.schedule %}
-        <tr>          
-          <td>{{event.date+', '+event.startTime+'-'+event.endTime}}</td>
+        <tr>
+          {% if event.endTime %}          
+            <td>{{event.date+', '+event.startTime+'-'+event.endTime}}</td>
+          {% else %}
+            <td>{{event.date+', '+event.startTime}}</td>
+          {% endif %}
           <td scope="row">{{event.title}}</td>
           <td style="white-space: pre-wrap;">{{event.speakers}}</td>
         </tr>


### PR DESCRIPTION
Quick fix: For #569 - the closing event doesn't have a time range, so conditional removes trailing hyphen if event endTime is unspecified.