### PR TITLE
Add paper share

### DIFF
--- a/miniconf/load_site_data.py
+++ b/miniconf/load_site_data.py
@@ -382,6 +382,18 @@ def get_card_image_path_for_paper(paper_id: str, paper_images_path: str) -> str:
     return f"{paper_images_path}/{paper_id}.png"
 
 
+def get_paper_share_text(paper_title: str, pdf_url: str):
+    share_text = "Here's an interesting read from #ACL2020 -\n" + paper_title + ": "
+    if pdf_url.startswith("https://www.aclweb.org/anthology/"):
+        return share_text + pdf_url.rstrip(".pdf")
+    elif pdf_url.startswith("https://www.mitpressjournals.org/doi/pdf/"):
+        return share_text + pdf_url.replace("pdf/", "", 1)
+    elif pdf_url.startswith("https://arxiv.org/abs/") and not pdf_url.endswith(".pdf"):
+        return share_text + pdf_url
+    else:
+        return ""
+
+
 def build_papers(
     raw_papers: List[Dict[str, str]],
     all_paper_sessions: List[Dict[str, Dict[str, Any]]],
@@ -475,6 +487,7 @@ def build_papers(
                 tldr=item["abstract"][:250] + "...",
                 pdf_url=item.get("pdf_url", ""),
                 demo_url=item.get("demo_url", ""),
+                share_text=get_paper_share_text(item["title"], item.get("pdf_url", "")),                
                 track=normalize_track_name(item.get("track", "")),
                 paper_type=item.get("paper_type", ""),
                 sessions=sessions_for_paper[item["UID"]],

--- a/miniconf/load_site_data.py
+++ b/miniconf/load_site_data.py
@@ -487,7 +487,7 @@ def build_papers(
                 tldr=item["abstract"][:250] + "...",
                 pdf_url=item.get("pdf_url", ""),
                 demo_url=item.get("demo_url", ""),
-                share_text=get_paper_share_text(item["title"], item.get("pdf_url", "")),                
+                share_text=get_paper_share_text(item["title"], item.get("pdf_url", "")),
                 track=normalize_track_name(item.get("track", "")),
                 paper_type=item.get("paper_type", ""),
                 sessions=sessions_for_paper[item["UID"]],

--- a/miniconf/site_data.py
+++ b/miniconf/site_data.py
@@ -61,6 +61,7 @@ class PaperContent:
     keywords: List[str]
     pdf_url: Optional[str]
     demo_url: Optional[str]
+    share_text: Optional[str]
     sessions: List[SessionInfo]
     similar_paper_uids: List[str]
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -409,3 +409,7 @@ div#papers_options > div {
 .fc-v-event:hover {
   background: rgb(234, 33, 45);
 }
+
+.toast {
+  background-color: #6c757d !important;
+}

--- a/templates/components.html
+++ b/templates/components.html
@@ -510,4 +510,27 @@
 <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.0.0/main.min.js" integrity="sha256-sXsoUUVbxnobZrwPZiGFeJrOUKZBoxXkWl0JXXdQp/o=" crossorigin="anonymous"></script>
 {%- endmacro %}
 
-
+{% macro share_scripts() -%}
+  <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
+  <script>
+    toastr.options = {
+    "closeButton": true,
+    "debug": false,
+    "newestOnTop": false,
+    "progressBar": false,
+    "positionClass": "toast-bottom-right",
+    "preventDuplicates": false,
+    "onclick": null,
+    "showDuration": "300",
+    "hideDuration": "1000",
+    "timeOut": "3000",
+    "extendedTimeOut": "1000",
+    "showEasing": "swing",
+    "hideEasing": "linear",
+    "showMethod": "fadeIn",
+    "hideMethod": "fadeOut"
+    }
+  </script>
+{%- endmacro %}

--- a/templates/paper.html
+++ b/templates/paper.html
@@ -16,13 +16,13 @@
 <meta name="citation_keywords" content="{{keyword}}" />
 {% endfor %}
 <meta name="citation_pdf_url" content="{{paper.content.pdf_url | default("")}}" />
-
+{{components.share_scripts()}}
 {% endblock %}
 
 {% block content %}
 
 <!-- Title -->
-<div class="pp-card m-3" style="">
+<div class="pp-card m-3">
   <div class="card-header">
     <h2 class="card-title main-title text-center" style="color: black">
       {{paper.content.title}}
@@ -54,6 +54,17 @@
         Demo
       </a>
       {% endif %}
+      {% if paper.content.share_text %}
+      <script>
+        let clipboard = new ClipboardJS('.share-text');
+        clipboard.on("success", function(e){
+          toastr.info("Paper info copied to clipboard!")
+        })
+      </script>
+      <button class="ml-3 btn btn-primary share-text" data-clipboard-text="{{paper.content.share_text}}">
+        Share
+      </button>
+      {% endif %}
     </div>
     <p class="card-text text-center h5">
 
@@ -69,6 +80,7 @@
 
   </div>
 </div>
+
 <div id="details" class="pp-card m-3 collapse">
   <div class="card-body">
     <div class="card-text">


### PR DESCRIPTION
Implements paper-sharing as mentioned in #465. Currently copies following template to clipboard, please check and edit:
> Here's an interesting read from #ACL2020 -
> paperTitle: paper_non_pdf_link

![](https://user-images.githubusercontent.com/58948612/87167365-d5722080-c29a-11ea-9d73-ed0261384b8d.gif)

